### PR TITLE
Fix error with gradient_accumulation_steps > 1 by calling cudagraph_mark_step_begin()

### DIFF
--- a/scripts/train_dynamics.py
+++ b/scripts/train_dynamics.py
@@ -158,6 +158,8 @@ def main():
         optimizer.zero_grad(set_to_none=True)
         if isinstance(dynamics_model, FSDPModule):
             dynamics_model.set_requires_gradient_sync(False)
+        if args.compile:
+            torch.compiler.cudagraph_mark_step_begin()
         for micro_batch in range(args.gradient_accumulation_steps):
             try:
                 x, _ = next(train_iter)

--- a/scripts/train_latent_actions.py
+++ b/scripts/train_latent_actions.py
@@ -120,6 +120,8 @@ def main():
         optimizer.zero_grad(set_to_none=True)
         if isinstance(model, FSDPModule):
             model.set_requires_gradient_sync(False)
+        if args.compile:
+            torch.compiler.cudagraph_mark_step_begin()
         for micro_batch in range(args.gradient_accumulation_steps):
             try:
                 (x, _) = next(train_iter)

--- a/scripts/train_video_tokenizer.py
+++ b/scripts/train_video_tokenizer.py
@@ -122,6 +122,8 @@ def main():
         optimizer.zero_grad(set_to_none=True)
         if isinstance(model, FSDPModule):
             model.set_requires_gradient_sync(False)
+        if args.compile:
+            torch.compiler.cudagraph_mark_step_begin()
         for micro_batch in range(args.gradient_accumulation_steps):
             try:
                 (x, _) = next(train_iter)


### PR DESCRIPTION
When I ran training with gradient_accumulation_steps > 1, I had this error:

```
RuntimeError: Error: accessing tensor output of CUDAGraphs that has been overwritten by a subsequent run. Stack trace: File "/home/sensho/tinyworlds/models/video_tokenizer.py", line 90, in forward
    embeddings = self.encoder(frames)  # [B, T, P, L]
  File "/home/sensho/tinyworlds/models/video_tokenizer.py", line 25, in forward
    embeddings = self.patch_embed(frames)  # [B, T, P, E]
  File "/home/sensho/tinyworlds/models/patch_embed.py", line 40, in forward
    x = self.proj(x) # [(B*T), E, Hp, Wp]. To prevent overwriting, clone the tensor outside of torch.compile() or call torch.compiler.cudagraph_mark_step_begin() before each model invocation.
```

Fixed this error by indicating new iterations just before the loop over micro batches.