### PR TITLE
Avoid saving the model with _orig_mod prefix if it's compiled

### DIFF
--- a/utils/utils.py
+++ b/utils/utils.py
@@ -182,7 +182,8 @@ def save_training_state(model, optimizer, scheduler, config, checkpoints_dir, pr
             ),
         )
     else:
-        state_dict = model.state_dict()
+        # Avoid saving the model with _orig_mod prefix if it's compiled
+        state_dict = getattr(model, '_orig_mod', model).state_dict()
         optimizer_state_dict = optimizer.state_dict()
     state = {
         'scheduler_state_dict': scheduler.state_dict() if scheduler is not None else None,


### PR DESCRIPTION
When I ran training without DDP or FSDP, the third dynamics training failed to start due to this error:

```
RuntimeError: Error(s) in loading state_dict for VideoTokenizer:
        Unexpected key(s) in state_dict: "_orig_mod.encoder.patch_embed.proj.weight", "_orig_mod.encoder.patch_embed.proj.bias", "_orig_mod.encoder.transformer.blocks.0.spatial_attn.q_proj.weight", "_orig_mod.encoder.transformer.blocks.0.spatial_attn.q_proj.bias", "_orig_mod.encoder.transformer.blocks.0.spatial_attn.k_proj.weight", ...
```

It seemed that all the modules get this `_orig_mod` prefix when the model is compiled.
- I saw the issue went away when DDP is enabled.

Following [this discussion](https://github.com/pytorch/pytorch/issues/101107#issuecomment-1869839379), removing the prefix solved the issue.